### PR TITLE
feat : 버튼 컴포넌트 생성 및 스토리북에 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@storybook/addon-docs": "^9.1.2",
     "@storybook/addon-onboarding": "^9.1.2",
     "@storybook/nextjs": "^9.1.2",
+    "@storybook/test": "^8.6.14",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "esbuild": "^0.25.9",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
     "eslint-plugin-storybook": "^9.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/nextjs':
         specifier: ^9.1.2
-        version: 9.1.2(@types/webpack@5.28.5(esbuild@0.25.8))(esbuild@0.25.8)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))
+        version: 9.1.2(@types/webpack@5.28.5(esbuild@0.25.9))(esbuild@0.25.9)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.9))
       '@storybook/test':
         specifier: ^8.6.14
         version: 8.6.14(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
@@ -69,6 +69,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.7(@types/react@19.1.10)
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.9
       eslint:
         specifier: ^9
         version: 9.33.0(jiti@2.5.1)
@@ -690,8 +693,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.8':
     resolution: {integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -702,8 +717,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.8':
     resolution: {integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -714,8 +741,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.8':
     resolution: {integrity: sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -726,8 +765,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.8':
     resolution: {integrity: sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -738,8 +789,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.8':
     resolution: {integrity: sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -750,8 +813,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.8':
     resolution: {integrity: sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -762,8 +837,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.8':
     resolution: {integrity: sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -774,8 +861,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.8':
     resolution: {integrity: sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -786,8 +885,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.8':
     resolution: {integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -798,8 +909,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.8':
     resolution: {integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -810,8 +933,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.8':
     resolution: {integrity: sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -822,8 +957,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.8':
     resolution: {integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -834,8 +981,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.8':
     resolution: {integrity: sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2468,6 +2627,11 @@ packages:
 
   esbuild@0.25.8:
     resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5168,79 +5332,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.25.8':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.25.8':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.8':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.8':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.8':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.8':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.25.8':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.25.8':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.25.8':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.8':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.8':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.8':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.8':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.8':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.25.8':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.8':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.8':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
   '@esbuild/sunos-x64@0.25.8':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.9':
     optional: true
 
   '@esbuild/win32-ia32@0.25.8':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.25.8':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.33.0(jiti@2.5.1))':
@@ -5468,7 +5710,7 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(esbuild@0.25.8))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(esbuild@0.25.9))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.9))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.45.0
@@ -5478,9 +5720,9 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.2
       source-map: 0.7.6
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     optionalDependencies:
-      '@types/webpack': 5.28.5(esbuild@0.25.8)
+      '@types/webpack': 5.28.5(esbuild@0.25.9)
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
 
@@ -5584,22 +5826,22 @@ snapshots:
     dependencies:
       storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
 
-  '@storybook/builder-webpack5@9.1.2(esbuild@0.25.8)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
+  '@storybook/builder-webpack5@9.1.2(esbuild@0.25.9)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/core-webpack': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.101.1(esbuild@0.25.8))
+      css-loader: 6.11.0(webpack@5.101.1(esbuild@0.25.9))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8))
-      html-webpack-plugin: 5.6.3(webpack@5.101.1(esbuild@0.25.8))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.9))
+      html-webpack-plugin: 5.6.3(webpack@5.101.1(esbuild@0.25.9))
       magic-string: 0.30.17
       storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      style-loader: 3.3.4(webpack@5.101.1(esbuild@0.25.8))
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.101.1(esbuild@0.25.8))
+      style-loader: 3.3.4(webpack@5.101.1(esbuild@0.25.9))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.9)(webpack@5.101.1(esbuild@0.25.9))
       ts-dedent: 2.2.0
-      webpack: 5.101.1(esbuild@0.25.8)
-      webpack-dev-middleware: 6.1.3(webpack@5.101.1(esbuild@0.25.8))
+      webpack: 5.101.1(esbuild@0.25.9)
+      webpack-dev-middleware: 6.1.3(webpack@5.101.1(esbuild@0.25.9))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -5634,7 +5876,7 @@ snapshots:
       '@vitest/utils': 2.1.9
       storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
 
-  '@storybook/nextjs@9.1.2(@types/webpack@5.28.5(esbuild@0.25.8))(esbuild@0.25.8)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))':
+  '@storybook/nextjs@9.1.2(@types/webpack@5.28.5(esbuild@0.25.9))(esbuild@0.25.9)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.9))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.0)
@@ -5649,33 +5891,33 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
       '@babel/runtime': 7.28.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(@types/webpack@5.28.5(esbuild@0.25.8))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))
-      '@storybook/builder-webpack5': 9.1.2(esbuild@0.25.8)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
-      '@storybook/preset-react-webpack': 9.1.2(esbuild@0.25.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(@types/webpack@5.28.5(esbuild@0.25.9))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.9))
+      '@storybook/builder-webpack5': 9.1.2(esbuild@0.25.9)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
+      '@storybook/preset-react-webpack': 9.1.2(esbuild@0.25.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
       '@storybook/react': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
       '@types/semver': 7.7.0
-      babel-loader: 9.2.1(@babel/core@7.28.0)(webpack@5.101.1(esbuild@0.25.8))
-      css-loader: 6.11.0(webpack@5.101.1(esbuild@0.25.8))
+      babel-loader: 9.2.1(@babel/core@7.28.0)(webpack@5.101.1(esbuild@0.25.9))
+      css-loader: 6.11.0(webpack@5.101.1(esbuild@0.25.9))
       image-size: 2.0.2
       loader-utils: 3.3.1
       next: 15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.101.1(esbuild@0.25.8))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.101.1(esbuild@0.25.9))
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.9))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.5(webpack@5.101.1(esbuild@0.25.8))
+      sass-loader: 16.0.5(webpack@5.101.1(esbuild@0.25.9))
       semver: 7.7.2
       storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      style-loader: 3.3.4(webpack@5.101.1(esbuild@0.25.8))
+      style-loader: 3.3.4(webpack@5.101.1(esbuild@0.25.9))
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.2
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -5694,10 +5936,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.2(esbuild@0.25.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
+  '@storybook/preset-react-webpack@9.1.2(esbuild@0.25.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/core-webpack': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.9))
       '@types/semver': 7.7.0
       find-up: 7.0.0
       magic-string: 0.30.17
@@ -5708,7 +5950,7 @@ snapshots:
       semver: 7.7.2
       storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       tsconfig-paths: 4.2.0
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -5718,7 +5960,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.9))':
     dependencies:
       debug: 4.4.1
       endent: 2.1.0
@@ -5728,7 +5970,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.2)
       tslib: 2.8.1
       typescript: 5.9.2
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -5948,11 +6190,11 @@ snapshots:
 
   '@types/semver@7.7.0': {}
 
-  '@types/webpack@5.28.5(esbuild@0.25.8)':
+  '@types/webpack@5.28.5(esbuild@0.25.9)':
     dependencies:
       '@types/node': 20.19.10
       tapable: 2.2.2
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -6436,12 +6678,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.28.0)(webpack@5.101.1(esbuild@0.25.8)):
+  babel-loader@9.2.1(@babel/core@7.28.0)(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.2
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.0):
     dependencies:
@@ -6765,7 +7007,7 @@ snapshots:
       randombytes: 2.1.0
       randomfill: 1.0.4
 
-  css-loader@6.11.0(webpack@5.101.1(esbuild@0.25.8)):
+  css-loader@6.11.0(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -6776,7 +7018,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   css-select@4.3.0:
     dependencies:
@@ -7050,10 +7292,10 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  esbuild-register@3.6.0(esbuild@0.25.8):
+  esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
       debug: 4.4.1
-      esbuild: 0.25.8
+      esbuild: 0.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -7085,6 +7327,36 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.8
       '@esbuild/win32-ia32': 0.25.8
       '@esbuild/win32-x64': 0.25.8
+    optional: true
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escalade@3.2.0: {}
 
@@ -7415,7 +7687,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -7430,7 +7702,7 @@ snapshots:
       semver: 7.7.2
       tapable: 2.2.2
       typescript: 5.9.2
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   form-data@4.0.4:
     dependencies:
@@ -7584,7 +7856,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.43.1
 
-  html-webpack-plugin@5.6.3(webpack@5.101.1(esbuild@0.25.8)):
+  html-webpack-plugin@5.6.3(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -7592,7 +7864,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.2
     optionalDependencies:
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -8049,7 +8321,7 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.101.1(esbuild@0.25.8)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8076,7 +8348,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   node-releases@2.0.19: {}
 
@@ -8261,14 +8533,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     transitivePeerDependencies:
       - typescript
 
@@ -8595,11 +8867,11 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  sass-loader@16.0.5(webpack@5.101.1(esbuild@0.25.8)):
+  sass-loader@16.0.5(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   scheduler@0.26.0: {}
 
@@ -8752,8 +9024,8 @@ snapshots:
       '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
-      esbuild: 0.25.8
-      esbuild-register: 3.6.0(esbuild@0.25.8)
+      esbuild: 0.25.9
+      esbuild-register: 3.6.0(esbuild@0.25.9)
       recast: 0.23.11
       semver: 7.7.2
       ws: 8.18.3
@@ -8855,9 +9127,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.101.1(esbuild@0.25.8)):
+  style-loader@3.3.4(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.1.0):
     dependencies:
@@ -8891,16 +9163,16 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.8)(webpack@5.101.1(esbuild@0.25.8)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.9)(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.43.1
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
     optionalDependencies:
-      esbuild: 0.25.8
+      esbuild: 0.25.9
 
   terser@5.43.1:
     dependencies:
@@ -9112,7 +9384,7 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
-  webpack-dev-middleware@6.1.3(webpack@5.101.1(esbuild@0.25.8)):
+  webpack-dev-middleware@6.1.3(webpack@5.101.1(esbuild@0.25.9)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -9120,7 +9392,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.2
     optionalDependencies:
-      webpack: 5.101.1(esbuild@0.25.8)
+      webpack: 5.101.1(esbuild@0.25.9)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -9132,7 +9404,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.101.1(esbuild@0.25.8):
+  webpack@5.101.1(esbuild@0.25.9):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -9156,7 +9428,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.101.1(esbuild@0.25.8))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.9)(webpack@5.101.1(esbuild@0.25.9))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,22 +38,25 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.1.0
-        version: 4.1.0(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+        version: 4.1.0(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
       '@storybook/addon-a11y':
         specifier: ^9.1.2
-        version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+        version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/addon-docs':
         specifier: ^9.1.2
-        version: 9.1.2(@types/react@19.1.10)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+        version: 9.1.2(@types/react@19.1.10)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/addon-onboarding':
         specifier: ^9.1.2
-        version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+        version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/nextjs':
         specifier: ^9.1.2
-        version: 9.1.2(esbuild@0.25.8)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))
+        version: 9.1.2(@types/webpack@5.28.5(esbuild@0.25.8))(esbuild@0.25.8)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))
+      '@storybook/test':
+        specifier: ^8.6.14
+        version: 8.6.14(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.11
@@ -74,13 +77,13 @@ importers:
         version: 15.4.6(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
       eslint-plugin-storybook:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@9.33.0(jiti@2.5.1))(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
+        version: 9.1.2(eslint@9.33.0(jiti@2.5.1))(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       storybook:
         specifier: ^9.1.2
-        version: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+        version: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       tailwindcss:
         specifier: ^4
         version: 4.1.11
@@ -1313,6 +1316,11 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
+  '@storybook/instrumenter@8.6.14':
+    resolution: {integrity: sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
   '@storybook/nextjs@9.1.2':
     resolution: {integrity: sha512-eriA+yUbGMTf0FkXtZHCr6fgH6Tq4JwsPtGqoz4kpgiqtHKb6EIou6A/5HOeas6iDajkem5Qnip+cD7OPVD6dg==}
     engines: {node: '>=20.0.0'}
@@ -1365,6 +1373,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@storybook/test@8.6.14':
+    resolution: {integrity: sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==}
+    peerDependencies:
+      storybook: ^8.6.14
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1457,13 +1470,23 @@ packages:
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
 
-  '@testing-library/dom@10.4.1':
-    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.5.0':
+    resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
   '@testing-library/jest-dom@6.6.4':
     resolution: {integrity: sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.5.2':
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
@@ -1538,6 +1561,9 @@ packages:
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
+  '@types/webpack@5.28.5':
+    resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
 
   '@typescript-eslint/eslint-plugin@8.39.1':
     resolution: {integrity: sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==}
@@ -1693,6 +1719,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@2.0.5':
+    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1707,11 +1736,26 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.0.5':
+    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/spy@2.0.5':
+    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.0.5':
+    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -2053,6 +2097,10 @@ packages:
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4050,8 +4098,16 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.3:
@@ -5081,13 +5137,13 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@chromatic-com/storybook@4.1.0(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@chromatic-com/storybook@4.1.0(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 12.2.0
       filesize: 10.1.6
       jsonfile: 6.1.0
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -5412,7 +5468,7 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(esbuild@0.25.8))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.45.0
@@ -5424,6 +5480,7 @@ snapshots:
       source-map: 0.7.6
       webpack: 5.101.1(esbuild@0.25.8)
     optionalDependencies:
+      '@types/webpack': 5.28.5(esbuild@0.25.8)
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
 
@@ -5504,32 +5561,32 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
-  '@storybook/addon-a11y@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@storybook/addon-a11y@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
 
-  '@storybook/addon-docs@9.1.2(@types/react@19.1.10)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@storybook/addon-docs@9.1.2(@types/react@19.1.10)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.1.10)(react@19.1.0)
-      '@storybook/csf-plugin': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+      '@storybook/csf-plugin': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@storybook/react-dom-shim': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+      '@storybook/react-dom-shim': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-onboarding@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@storybook/addon-onboarding@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
 
-  '@storybook/builder-webpack5@9.1.2(esbuild@0.25.8)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
+  '@storybook/builder-webpack5@9.1.2(esbuild@0.25.8)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
     dependencies:
-      '@storybook/core-webpack': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+      '@storybook/core-webpack': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 6.11.0(webpack@5.101.1(esbuild@0.25.8))
@@ -5537,7 +5594,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8))
       html-webpack-plugin: 5.6.3(webpack@5.101.1(esbuild@0.25.8))
       magic-string: 0.30.17
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       style-loader: 3.3.4(webpack@5.101.1(esbuild@0.25.8))
       terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.101.1(esbuild@0.25.8))
       ts-dedent: 2.2.0
@@ -5554,14 +5611,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/core-webpack@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@storybook/core-webpack@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@storybook/csf-plugin@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -5571,7 +5628,13 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/nextjs@9.1.2(esbuild@0.25.8)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))':
+  '@storybook/instrumenter@8.6.14(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@vitest/utils': 2.1.9
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+
+  '@storybook/nextjs@9.1.2(@types/webpack@5.28.5(esbuild@0.25.8))(esbuild@0.25.8)(next@15.4.6(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.0)
@@ -5586,10 +5649,10 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
       '@babel/runtime': 7.28.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))
-      '@storybook/builder-webpack5': 9.1.2(esbuild@0.25.8)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
-      '@storybook/preset-react-webpack': 9.1.2(esbuild@0.25.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
-      '@storybook/react': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(@types/webpack@5.28.5(esbuild@0.25.8))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.1(esbuild@0.25.8))
+      '@storybook/builder-webpack5': 9.1.2(esbuild@0.25.8)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
+      '@storybook/preset-react-webpack': 9.1.2(esbuild@0.25.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
+      '@storybook/react': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
       '@types/semver': 7.7.0
       babel-loader: 9.2.1(@babel/core@7.28.0)(webpack@5.101.1(esbuild@0.25.8))
       css-loader: 6.11.0(webpack@5.101.1(esbuild@0.25.8))
@@ -5605,7 +5668,7 @@ snapshots:
       resolve-url-loader: 5.0.0
       sass-loader: 16.0.5(webpack@5.101.1(esbuild@0.25.8))
       semver: 7.7.2
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       style-loader: 3.3.4(webpack@5.101.1(esbuild@0.25.8))
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
       tsconfig-paths: 4.2.0
@@ -5631,9 +5694,9 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.2(esbuild@0.25.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
+  '@storybook/preset-react-webpack@9.1.2(esbuild@0.25.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
     dependencies:
-      '@storybook/core-webpack': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+      '@storybook/core-webpack': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.1(esbuild@0.25.8))
       '@types/semver': 7.7.0
       find-up: 7.0.0
@@ -5643,7 +5706,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
       semver: 7.7.2
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       tsconfig-paths: 4.2.0
       webpack: 5.101.1(esbuild@0.25.8)
     optionalDependencies:
@@ -5669,21 +5732,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+  '@storybook/react-dom-shim@9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
 
-  '@storybook/react@9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
+  '@storybook/react@9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+      '@storybook/react-dom-shim': 9.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
     optionalDependencies:
       typescript: 5.9.2
+
+  '@storybook/test@8.6.14(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/instrumenter': 8.6.14(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))
+      '@testing-library/dom': 10.4.0
+      '@testing-library/jest-dom': 6.5.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/expect': 2.0.5
+      '@vitest/spy': 2.0.5
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -5761,16 +5835,26 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.11
 
-  '@testing-library/dom@10.4.1':
+  '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.28.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
+      chalk: 4.1.2
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
-      picocolors: 1.1.1
       pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.5.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.3
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
 
   '@testing-library/jest-dom@6.6.4':
     dependencies:
@@ -5782,9 +5866,13 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
-      '@testing-library/dom': 10.4.1
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -5859,6 +5947,18 @@ snapshots:
   '@types/resolve@1.20.6': {}
 
   '@types/semver@7.7.0': {}
+
+  '@types/webpack@5.28.5(esbuild@0.25.8)':
+    dependencies:
+      '@types/node': 20.19.10
+      tapable: 2.2.2
+      webpack: 5.101.1(esbuild@0.25.8)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -6012,6 +6112,13 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@2.0.5':
+    dependencies:
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.2.1
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.2
@@ -6028,13 +6135,38 @@ snapshots:
     optionalDependencies:
       vite: 7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
 
+  '@vitest/pretty-format@2.0.5':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/spy@2.0.5':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
+
+  '@vitest/utils@2.0.5':
+    dependencies:
+      '@vitest/pretty-format': 2.0.5
+      estree-walker: 3.0.3
+      loupe: 3.2.0
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.0
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -6466,6 +6598,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.0
       pathval: 2.0.1
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -7081,11 +7218,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@9.1.2(eslint@9.33.0(jiti@2.5.1))(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2):
+  eslint-plugin-storybook@9.1.2(eslint@9.33.0(jiti@2.5.1))(storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.33.0(jiti@2.5.1)
-      storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      storybook: 9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8606,11 +8743,11 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@9.1.2(@testing-library/dom@10.4.1)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)):
+  storybook@9.1.2(@testing-library/dom@10.4.0)(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.4
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
       '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@20.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       '@vitest/spy': 3.2.4
@@ -8783,7 +8920,11 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.3: {}
 

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/utils/classNameMerge";
+
+// 기본 아이콘으로 사용자 제공 SVG 사용 – inline 컴포넌트로 변환 (fill="white" 기본, className으로 오버라이드)
+const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M9.23362 4.12327C9.52228 3.45035 10.4763 3.45054 10.7652 4.12327L12.3668 7.86269C12.451 8.05936 12.608 8.21617 12.8046 8.30052L16.544 9.90208C17.2173 10.1907 17.2173 11.145 16.544 11.4337L12.8046 13.0352C12.6079 13.1195 12.451 13.2764 12.3668 13.473L10.7652 17.2125L10.7042 17.3305C10.3834 17.8466 9.61541 17.8466 9.29466 17.3305L9.23362 17.2125L7.63206 13.473C7.55824 13.301 7.4288 13.1593 7.26585 13.0702L7.19423 13.0352L3.45481 11.4337C2.78208 11.1448 2.7819 10.1907 3.45481 9.90208L7.19423 8.30052C7.39106 8.21622 7.54776 8.05951 7.63206 7.86269L9.23362 4.12327ZM8.78115 8.35504C8.57041 8.84696 8.1785 9.23887 7.68658 9.4496L4.84153 10.6679L7.68658 11.8861C8.17835 12.0968 8.57036 12.489 8.78115 12.9807L9.99941 15.8249L11.2177 12.9807L11.3047 12.8017C11.5276 12.3941 11.8817 12.0706 12.3122 11.8861L15.1565 10.6679L12.3122 9.4496C11.8205 9.23882 11.4283 8.84681 11.2177 8.35504L9.99941 5.50999L8.78115 8.35504Z" fill="currentColor"/>
+  </svg>
+);
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-border-focus-ring)] focus-visible:ring-offset-2 disabled:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        "primary-filled": "bg-[var(--color-bg-interactive-primary)] text-[var(--color-text-interactive-inverse)] hover:bg-[var(--color-text-interactive-primary-hovered)]",
+        "primary-neutral": "bg-[var(--color-bg-tertiary-light)] text-[var(--color-text-info)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered-darker)]",
+        "primary-transparent": "bg-transparent text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-transparent-dark)]",
+        "primary-inversed": "bg-[var(--color-text-interactive-inverse)] text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered)]",
+        "secondary-filled": "bg-[var(--color-text-interactive-secondary)] text-[var(--color-text-interactive-inverse)]",
+        "secondary-inversed": "bg-[var(--color-text-interactive-inverse)] text-[var(--color-text-primary)]",
+        "secondary-neutral": "bg-transparent text-[var(--color-text-primary)]",
+        "secondary-outlined": "bg-transparent text-[var(--color-text-primary)] border border-[var(--color-secondary-filled)]",
+        "secondary-transparent": "bg-transparent text-[var(--color-text-interactive-secondary)]",
+        "secondary-translucent": "bg-[var(--color-translucent-bg)] text-[var(--color-text-interactive-secondary)]",
+        "disabled": "bg-[var(--color-bg-disabled)] text-[var(--color-text-transparent-dark)] cursor-not-allowed",
+      },
+      size: {
+        sm: "h-11 px-3 py-3 leading-5 body-sm-semibold",
+        md: "h-9 px-4 py-2 leading-4 caption-md semibold",
+        lg: "h-12 px-4 py-3 leading-6 body-lg-semibold",
+      },
+      shape: {
+        default: "rounded-lg",
+        rounded: "rounded-full",
+      },
+    },
+    defaultVariants: {
+      variant: "primary-filled",
+      size: "md",
+      shape: "default",
+    },
+  }
+);
+
+const iconVariants = cva("", {
+  variants: {
+    variant: {
+      "primary-filled": "text-[var(--color-icon-interactive-inverse)]",
+      "primary-neutral": "text-[var(--color-icon-info)]",
+      "primary-transparent": "text-[var(--color-icon-interactive-primary)]",
+      "primary-inversed": "text-[var(--color-icon-interactive-primary)]",
+      "secondary-filled": "text-[var(--color-icon-interactive-inverse-subtle)]",
+      "secondary-inversed": "text-[var(--color-icon-tertiary)]",
+      "secondary-neutral": "text-[var(--color-icon-tertiary)]",
+      "secondary-outlined": "text-[var(--color-icon-tertiary)]",
+      "secondary-transparent": "text-[var(--color-icon-transparent-darker)]",
+      "secondary-translucent": "text-[var(--color-icon-transparent-darker)]",
+      "disabled": "text-[var(--color-icon-transparent-dark)]",
+    },
+  },
+});
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  iconSize?: string;
+  loading?: boolean;
+}
+
+const ButtonComponent = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, shape, leftIcon, rightIcon, iconSize = "20px", children, disabled, loading = false, ...props }, ref) => {
+    const iconVariant = disabled || loading ? "disabled" : variant;
+    const iconClass = cn(
+      iconVariants({ variant: iconVariant }),
+      `[&>svg]:w-[${iconSize}] [&>svg]:h-[${iconSize}]`
+    );
+
+    // leftIcon/rightIcon이 true면 기본 StarIcon을 렌더링
+    const renderIcon = (icon: React.ReactNode) => {
+      if (icon === true) {
+        return <StarIcon className={iconClass} />;
+      }
+      if (React.isValidElement(icon)) {
+        return React.cloneElement(icon, { className: iconClass }as any);
+      }
+      return icon;
+    };
+
+    return (
+      <button
+        className={cn(buttonVariants({ variant: disabled || loading ? "disabled" : variant, size, shape }), className)}
+        ref={ref}
+        disabled={disabled || loading}
+        aria-disabled={disabled || loading ? "true" : undefined}
+        aria-busy={loading ? "true" : undefined}
+        {...props}
+      >
+        {leftIcon && renderIcon(leftIcon)}
+        {children}
+        {rightIcon && renderIcon(rightIcon)}
+      </button>
+    );
+  }
+);
+
+ButtonComponent.displayName = "Button";
+
+export const Button = ButtonComponent;
+
+export { buttonVariants, StarIcon };

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -10,17 +10,17 @@ const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
 );
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bg-border-focus-ring focus-visible:ring-offset-2 disabled:pointer-events-none",
+  "inline-flex items-center justify-center gap-2 font-medium whitespace-nowrap transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-border-focus-ring)] focus:ring-offset-2 disabled:pointer-events-none",
   {
     variants: {
       variant: {
         primaryFilled: "bg-bg-interactive-primary text-text-interactive-inverse hover:bg-text-interactive-primary-hovered",
-        primaryNeutral: "bg-bg-tertiary-light text-text-info hover:text-text-interactive-primary-hovered hover:bg-bg-interactive-base-hovered-darker",
+        primaryNeutral: "bg-bg-tertiary-light text-text-info hover:text-text-interactive-primary-hovered hover:bg-bg-interactive-base-hovered-darker focus:border focus:border-border-brand focus:bg-bg-info-subtle",
         primaryTransparent: "bg-transparent text-text-interactive-primary hover:text-text-interactive-primary-hovered hover:bg-bg-transparent-dark",
         primaryInversed: "bg-bg-interactive-base text-text-interactive-primary hover:text-text-interactive-primary-hovered hover:bg-bg-interactive-base-hovered",
         secondaryFilled: "bg-bg-interactive-secondary text-text-interactive-inverse hover:text-text-interactive-inverse hover:bg-bg-interactive-secondary-hovered",
-        secondaryInversed: "bg-text-interactive-base text-text-primary hover:bg-bg-interactive-base-hovered",
-        secondaryNeutral: "bg-bg-tertiary-light text-text-primary hover:bg-bg-interactive-base-hovered-darker",
+        secondaryInversed: "bg-text-interactive-base text-text-primary hover:bg-bg-interactive-base-hovered focus:bg-bg-interactive-base",
+        secondaryNeutral: "bg-bg-tertiary-light text-text-primary hover:bg-bg-interactive-base-hovered-darker focus:border focus:border-[#000] focus:bg-bg-interactive-base",
         secondaryOutlined: "bg-transparent text-text-primary border border-border-tertiary hover:bg-bg-interactive-base-hovered",
         secondaryTransparent: "bg-transparent text-text-interactive-secondary hover:bg-bg-transparent-dark hover:text-text-interactive-secondary-hovered",
         secondaryTranslucent: "bg-bg-transparent-dark text-text-interactive-secondary hover:bg-bg-transparent-semi-darker hover:text-text-interactive-secondary-hovered",

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/utils/classNameMerge";
 
 // 기본 아이콘으로 사용자 제공 SVG 사용 – inline 컴포넌트로 변환 (fill="white" 기본, className으로 오버라이드)
 const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path fill-rule="evenodd" clip-rule="evenodd" d="M9.23362 4.12327C9.52228 3.45035 10.4763 3.45054 10.7652 4.12327L12.3668 7.86269C12.451 8.05936 12.608 8.21617 12.8046 8.30052L16.544 9.90208C17.2173 10.1907 17.2173 11.145 16.544 11.4337L12.8046 13.0352C12.6079 13.1195 12.451 13.2764 12.3668 13.473L10.7652 17.2125L10.7042 17.3305C10.3834 17.8466 9.61541 17.8466 9.29466 17.3305L9.23362 17.2125L7.63206 13.473C7.55824 13.301 7.4288 13.1593 7.26585 13.0702L7.19423 13.0352L3.45481 11.4337C2.78208 11.1448 2.7819 10.1907 3.45481 9.90208L7.19423 8.30052C7.39106 8.21622 7.54776 8.05951 7.63206 7.86269L9.23362 4.12327ZM8.78115 8.35504C8.57041 8.84696 8.1785 9.23887 7.68658 9.4496L4.84153 10.6679L7.68658 11.8861C8.17835 12.0968 8.57036 12.489 8.78115 12.9807L9.99941 15.8249L11.2177 12.9807L11.3047 12.8017C11.5276 12.3941 11.8817 12.0706 12.3122 11.8861L15.1565 10.6679L12.3122 9.4496C11.8205 9.23882 11.4283 8.84681 11.2177 8.35504L9.99941 5.50999L8.78115 8.35504Z" fill="currentColor"/>
   </svg>
 );
@@ -17,13 +17,13 @@ const buttonVariants = cva(
         "primary-filled": "bg-[var(--color-bg-interactive-primary)] text-[var(--color-text-interactive-inverse)] hover:bg-[var(--color-text-interactive-primary-hovered)]",
         "primary-neutral": "bg-[var(--color-bg-tertiary-light)] text-[var(--color-text-info)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered-darker)]",
         "primary-transparent": "bg-transparent text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-transparent-dark)]",
-        "primary-inversed": "bg-[var(--color-text-interactive-inverse)] text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered)]",
-        "secondary-filled": "bg-[var(--color-text-interactive-secondary)] text-[var(--color-text-interactive-inverse)]",
-        "secondary-inversed": "bg-[var(--color-text-interactive-inverse)] text-[var(--color-text-primary)]",
-        "secondary-neutral": "bg-transparent text-[var(--color-text-primary)]",
-        "secondary-outlined": "bg-transparent text-[var(--color-text-primary)] border border-[var(--color-secondary-filled)]",
-        "secondary-transparent": "bg-transparent text-[var(--color-text-interactive-secondary)]",
-        "secondary-translucent": "bg-[var(--color-translucent-bg)] text-[var(--color-text-interactive-secondary)]",
+        "primary-inversed": "bg-[var(--color-bg-interactive-base)] text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered)]",
+        "secondary-filled": "bg-[var(--color-bg-interactive-secondary)] text-[var(--color-text-interactive-inverse)] hover:text-[var(--color-text-interactive-inverse)] hover:bg-[var(--color-bg-interactive-secondary-hovered)]",
+        "secondary-inversed": "bg-[var(--color-text-interactive-base)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-interactive-base-hovered)]   ",
+        "secondary-neutral": "bg-[var(--color-bg-tertiary-light)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-interactive-base-hovered-darker)]",
+        "secondary-outlined": "bg-transparent text-[var(--color-text-primary)] border border-[var(--color-border-tertiary)] hover:bg-[var(--color-bg-interactive-base-hovered)]",
+        "secondary-transparent": "bg-transparent text-[var(--color-text-interactive-secondary)] hover:bg-[var(--color-bg-transparent-dark)] hover:text-[var(--color-text-interactive-secondary-hovered)]",
+        "secondary-translucent": "bg-[var(--color-bg-transparent-dark)] text-[var(--color-text-interactive-secondary)] hover:bg-[var(--color-bg-transparent-semi-darker)] hover:text-[var(--color-text-interactive-secondary-hovered)]",
         "disabled": "bg-[var(--color-bg-disabled)] text-[var(--color-text-transparent-dark)] cursor-not-allowed",
       },
       size: {
@@ -67,16 +67,14 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
-  iconSize?: string;
-  loading?: boolean;
 }
 
 const ButtonComponent = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, shape, leftIcon, rightIcon, iconSize = "20px", children, disabled, loading = false, ...props }, ref) => {
-    const iconVariant = disabled || loading ? "disabled" : variant;
+  ({ className, variant, size, shape, leftIcon, rightIcon, children, disabled, ...props }, ref) => {
+    const iconVariant = disabled ? "disabled" : variant;
     const iconClass = cn(
       iconVariants({ variant: iconVariant }),
-      `[&>svg]:w-[${iconSize}] [&>svg]:h-[${iconSize}]`
+      "[&>svg]:w-[20px] [&>svg]:h-[20px]"
     );
 
     // leftIcon/rightIcon이 true면 기본 StarIcon을 렌더링
@@ -92,11 +90,10 @@ const ButtonComponent = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <button
-        className={cn(buttonVariants({ variant: disabled || loading ? "disabled" : variant, size, shape }), className)}
+        className={cn(buttonVariants({ variant: disabled ? "disabled" : variant, size, shape }), className)}
         ref={ref}
-        disabled={disabled || loading}
-        aria-disabled={disabled || loading ? "true" : undefined}
-        aria-busy={loading ? "true" : undefined}
+        disabled={disabled}
+        aria-disabled={disabled ? "true" : undefined}
         {...props}
       >
         {leftIcon && renderIcon(leftIcon)}

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -2,29 +2,29 @@ import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/classNameMerge";
 
-// 기본 아이콘으로 사용자 제공 SVG 사용 – inline 컴포넌트로 변환 (fill="white" 기본, className으로 오버라이드)
+// 기본 아이콘으로 사용자 제공 SVG 사용 – inline 컴포넌트로 변환 (fill="currentColor"로 변경, className으로 색상/크기 오버라이드)
 const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path fill-rule="evenodd" clip-rule="evenodd" d="M9.23362 4.12327C9.52228 3.45035 10.4763 3.45054 10.7652 4.12327L12.3668 7.86269C12.451 8.05936 12.608 8.21617 12.8046 8.30052L16.544 9.90208C17.2173 10.1907 17.2173 11.145 16.544 11.4337L12.8046 13.0352C12.6079 13.1195 12.451 13.2764 12.3668 13.473L10.7652 17.2125L10.7042 17.3305C10.3834 17.8466 9.61541 17.8466 9.29466 17.3305L9.23362 17.2125L7.63206 13.473C7.55824 13.301 7.4288 13.1593 7.26585 13.0702L7.19423 13.0352L3.45481 11.4337C2.78208 11.1448 2.7819 10.1907 3.45481 9.90208L7.19423 8.30052C7.39106 8.21622 7.54776 8.05951 7.63206 7.86269L9.23362 4.12327ZM8.78115 8.35504C8.57041 8.84696 8.1785 9.23887 7.68658 9.4496L4.84153 10.6679L7.68658 11.8861C8.17835 12.0968 8.57036 12.489 8.78115 12.9807L9.99941 15.8249L11.2177 12.9807L11.3047 12.8017C11.5276 12.3941 11.8817 12.0706 12.3122 11.8861L15.1565 10.6679L12.3122 9.4496C11.8205 9.23882 11.4283 8.84681 11.2177 8.35504L9.99941 5.50999L8.78115 8.35504Z" fill="currentColor"/>
   </svg>
 );
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-border-focus-ring)] focus-visible:ring-offset-2 disabled:pointer-events-none",
+  "inline-flex items-center justify-center gap-2 font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-bg-border-focus-ring focus-visible:ring-offset-2 disabled:pointer-events-none",
   {
     variants: {
       variant: {
-        "primary-filled": "bg-[var(--color-bg-interactive-primary)] text-[var(--color-text-interactive-inverse)] hover:bg-[var(--color-text-interactive-primary-hovered)]",
-        "primary-neutral": "bg-[var(--color-bg-tertiary-light)] text-[var(--color-text-info)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered-darker)]",
-        "primary-transparent": "bg-transparent text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-transparent-dark)]",
-        "primary-inversed": "bg-[var(--color-bg-interactive-base)] text-[var(--color-text-interactive-primary)] hover:text-[var(--color-text-interactive-primary-hovered)] hover:bg-[var(--color-bg-interactive-base-hovered)]",
-        "secondary-filled": "bg-[var(--color-bg-interactive-secondary)] text-[var(--color-text-interactive-inverse)] hover:text-[var(--color-text-interactive-inverse)] hover:bg-[var(--color-bg-interactive-secondary-hovered)]",
-        "secondary-inversed": "bg-[var(--color-text-interactive-base)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-interactive-base-hovered)]   ",
-        "secondary-neutral": "bg-[var(--color-bg-tertiary-light)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-interactive-base-hovered-darker)]",
-        "secondary-outlined": "bg-transparent text-[var(--color-text-primary)] border border-[var(--color-border-tertiary)] hover:bg-[var(--color-bg-interactive-base-hovered)]",
-        "secondary-transparent": "bg-transparent text-[var(--color-text-interactive-secondary)] hover:bg-[var(--color-bg-transparent-dark)] hover:text-[var(--color-text-interactive-secondary-hovered)]",
-        "secondary-translucent": "bg-[var(--color-bg-transparent-dark)] text-[var(--color-text-interactive-secondary)] hover:bg-[var(--color-bg-transparent-semi-darker)] hover:text-[var(--color-text-interactive-secondary-hovered)]",
-        "disabled": "bg-[var(--color-bg-disabled)] text-[var(--color-text-transparent-dark)] cursor-not-allowed",
+        primaryFilled: "bg-bg-interactive-primary text-text-interactive-inverse hover:bg-text-interactive-primary-hovered",
+        primaryNeutral: "bg-bg-tertiary-light text-text-info hover:text-text-interactive-primary-hovered hover:bg-bg-interactive-base-hovered-darker",
+        primaryTransparent: "bg-transparent text-text-interactive-primary hover:text-text-interactive-primary-hovered hover:bg-bg-transparent-dark",
+        primaryInversed: "bg-bg-interactive-base text-text-interactive-primary hover:text-text-interactive-primary-hovered hover:bg-bg-interactive-base-hovered",
+        secondaryFilled: "bg-bg-interactive-secondary text-text-interactive-inverse hover:text-text-interactive-inverse hover:bg-bg-interactive-secondary-hovered",
+        secondaryInversed: "bg-text-interactive-base text-text-primary hover:bg-bg-interactive-base-hovered",
+        secondaryNeutral: "bg-bg-tertiary-light text-text-primary hover:bg-bg-interactive-base-hovered-darker",
+        secondaryOutlined: "bg-transparent text-text-primary border border-border-tertiary hover:bg-bg-interactive-base-hovered",
+        secondaryTransparent: "bg-transparent text-text-interactive-secondary hover:bg-bg-transparent-dark hover:text-text-interactive-secondary-hovered",
+        secondaryTranslucent: "bg-bg-transparent-dark text-text-interactive-secondary hover:bg-bg-transparent-semi-darker hover:text-text-interactive-secondary-hovered",
+        disabled: "bg-bg-disabled text-text-transparent-dark cursor-not-allowed",
       },
       size: {
         sm: "h-11 px-3 py-3 leading-5 body-sm-semibold",
@@ -37,7 +37,7 @@ const buttonVariants = cva(
       },
     },
     defaultVariants: {
-      variant: "primary-filled",
+      variant: "primaryFilled",
       size: "md",
       shape: "default",
     },
@@ -47,17 +47,17 @@ const buttonVariants = cva(
 const iconVariants = cva("", {
   variants: {
     variant: {
-      "primary-filled": "text-[var(--color-icon-interactive-inverse)]",
-      "primary-neutral": "text-[var(--color-icon-info)]",
-      "primary-transparent": "text-[var(--color-icon-interactive-primary)]",
-      "primary-inversed": "text-[var(--color-icon-interactive-primary)]",
-      "secondary-filled": "text-[var(--color-icon-interactive-inverse-subtle)]",
-      "secondary-inversed": "text-[var(--color-icon-tertiary)]",
-      "secondary-neutral": "text-[var(--color-icon-tertiary)]",
-      "secondary-outlined": "text-[var(--color-icon-tertiary)]",
-      "secondary-transparent": "text-[var(--color-icon-transparent-darker)]",
-      "secondary-translucent": "text-[var(--color-icon-transparent-darker)]",
-      "disabled": "text-[var(--color-icon-transparent-dark)]",
+      primaryFilled: "text-icon-interactive-inverse",
+      primaryNeutral: "text-icon-info",
+      primaryTransparent: "text-icon-interactive-primary",
+      primaryInversed: "text-icon-interactive-primary",
+      secondaryFilled: "text-icon-interactive-inverse-subtle",
+      secondaryInversed: "text-icon-tertiary",
+      secondaryNeutral: "text-icon-tertiary",
+      secondaryOutlined: "text-icon-tertiary",
+      secondaryTransparent: "text-icon-transparent-darker",
+      secondaryTranslucent: "text-icon-transparent-darker",
+      disabled: "text-icon-transparent-dark",
     },
   },
 });
@@ -65,35 +65,38 @@ const iconVariants = cva("", {
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
+  leftIcon?: React.ReactNode | boolean;
+  rightIcon?: React.ReactNode | boolean;
+  iconSize?: string;
+  loading?: boolean;
 }
 
 const ButtonComponent = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, shape, leftIcon, rightIcon, children, disabled, ...props }, ref) => {
-    const iconVariant = disabled ? "disabled" : variant;
+  ({ className, variant, size, shape, leftIcon, rightIcon, iconSize = "20px", children, disabled, loading = false, ...props }, ref) => {
+    const effectiveVariant = disabled || loading ? "disabled" : variant;
     const iconClass = cn(
-      iconVariants({ variant: iconVariant }),
-      "[&>svg]:w-[20px] [&>svg]:h-[20px]"
+      iconVariants({ variant: effectiveVariant }),
+      `flex-shrink-0 min-w-[${iconSize}] min-h-[${iconSize}] [&>svg]:w-[${iconSize}] [&>svg]:h-[${iconSize}]`  // flex-shrink-0 + min-w/h for 크기 고정, shrink 방지
     );
 
     // leftIcon/rightIcon이 true면 기본 StarIcon을 렌더링
-    const renderIcon = (icon: React.ReactNode) => {
+    const renderIcon = (icon: React.ReactNode | boolean) => {
       if (icon === true) {
         return <StarIcon className={iconClass} />;
       }
       if (React.isValidElement(icon)) {
-        return React.cloneElement(icon, { className: iconClass }as any);
+        return React.cloneElement(icon as React.ReactElement, { className: iconClass }as any);
       }
       return icon;
     };
 
     return (
       <button
-        className={cn(buttonVariants({ variant: disabled ? "disabled" : variant, size, shape }), className)}
+        className={cn(buttonVariants({ variant: effectiveVariant, size, shape }), className)}
         ref={ref}
-        disabled={disabled}
-        aria-disabled={disabled ? "true" : undefined}
+        disabled={disabled || loading}
+        aria-disabled={disabled || loading ? "true" : undefined}
+        aria-busy={loading ? "true" : undefined}
         {...props}
       >
         {leftIcon && renderIcon(leftIcon)}

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -14,9 +14,9 @@ const meta: Meta<typeof Button> = {
     variant: {
       control: "select",
       options: [
-        "primary-filled", "primary-neutral", "primary-transparent", "primary-inversed",
-        "secondary-filled", "secondary-inversed", "secondary-neutral", "secondary-outlined",
-        "secondary-transparent", "secondary-translucent", "disabled",
+        "primaryFilled", "primaryNeutral", "primaryTransparent", "primaryInversed",
+        "secondaryFilled", "secondaryInversed", "secondaryNeutral", "secondaryOutlined",
+        "secondaryTransparent", "secondaryTranslucent", "disabled",
       ],
       description: "버튼 테마",
     },
@@ -25,7 +25,6 @@ const meta: Meta<typeof Button> = {
     leftIcon: { control: "boolean", description: "왼쪽 아이콘 표시 (StarIcon 사용)" },
     rightIcon: { control: "boolean", description: "오른쪽 아이콘 표시 (StarIcon 사용)" },
     disabled: { control: "boolean", description: "비활성화" },
-  // ...existing code...
     children: { control: "text", defaultValue: "Button" },
   },
   tags: ["autodocs"], // 자동 문서화 활성화 (Storybook 8+ 베스트 프랙티스)
@@ -46,40 +45,39 @@ export const Default: Story = {
 
 export const Focused: Story = {
   render: () => (
-    <div className="grid grid-cols-3 gap-4">
-      <Button variant="primary-filled">Primary Filled Focused</Button>
-      <Button variant="secondary-outlined">Secondary Outlined Focused</Button>
-      <Button variant="primary-transparent" disabled>Disabled (No Focus)</Button>
+    <div className="flex flex-wrap gap-4">
+      <Button variant="primaryFilled">Primary Filled Focused</Button>
+      <Button variant="secondaryOutlined">Secondary Outlined Focused</Button>
+      <Button variant="primaryTransparent" disabled>Disabled (No Focus)</Button>
     </div>
   ),
   parameters: {
     docs: { description: { story: "포커스 상태 테스트: Tab 키로 확인. 접근성 강화 (ARIA 속성)." } },
   },
-  // play 함수 제거: 사용자가 직접 Tab 키로 포커스 테스트 (Storybook 8.5+ Test runner 추천으로 별도 테스트)
 };
 
 export const PrimaryVariants: Story = {
   render: () => (
-    <div className="grid grid-cols-4 gap-4">
-      <Button variant="primary-filled">Filled</Button>
-      <Button variant="primary-neutral">Neutral</Button>
-      <Button variant="primary-transparent">Transparent</Button>
-      <Button variant="primary-inversed">Inversed</Button>
-      <Button variant="primary-filled" disabled>Disabled Filled</Button>
+    <div className="flex flex-wrap gap-4">
+      <Button variant="primaryFilled">Filled</Button>
+      <Button variant="primaryNeutral">Neutral</Button>
+      <Button variant="primaryTransparent">Transparent</Button>
+      <Button variant="primaryInversed">Inversed</Button>
+      <Button variant="primaryFilled" disabled>Disabled Filled</Button>
     </div>
   ),
 };
 
 export const SecondaryVariants: Story = {
   render: () => (
-    <div className="grid grid-cols-4 gap-4">
-      <Button variant="secondary-filled">Filled</Button>
-      <Button variant="secondary-inversed">Inversed</Button>
-      <Button variant="secondary-neutral">Neutral</Button>
-      <Button variant="secondary-outlined">Outlined</Button>
-      <Button variant="secondary-transparent">Transparent</Button>
-      <Button variant="secondary-translucent">Translucent</Button>
-      <Button variant="secondary-filled" disabled>Disabled Filled</Button>
+    <div className="flex flex-wrap gap-4">
+      <Button variant="secondaryFilled">Filled</Button>
+      <Button variant="secondaryInversed">Inversed</Button>
+      <Button variant="secondaryNeutral">Neutral</Button>
+      <Button variant="secondaryOutlined">Outlined</Button>
+      <Button variant="secondaryTransparent">Transparent</Button>
+      <Button variant="secondaryTranslucent">Translucent</Button>
+      <Button variant="secondaryFilled" disabled>Disabled Filled</Button>
     </div>
   ),
 };
@@ -103,7 +101,6 @@ export const Shapes: Story = {
   ),
 };
 
-// WithIcons, LeftIconOnly, RightIconOnly 등에서 leftIcon/rightIcon이 true면 DefaultSvgIcon을 넘김
 export const WithIcons: Story = {
   args: {
     leftIcon: true,
@@ -112,9 +109,9 @@ export const WithIcons: Story = {
   },
   render: (args) => (
     <div className="flex gap-4">
-  <Button {...args} leftIcon={true} rightIcon={true}>Small Icon</Button>
-  <Button {...args} leftIcon={true} rightIcon={true}>Default Icon</Button>
-  <Button {...args} leftIcon={true} rightIcon={true}>Large Icon</Button>
+      <Button {...args} leftIcon={true} rightIcon={true}>Small Icon</Button>
+      <Button {...args} leftIcon={true} rightIcon={true}>Default Icon</Button>
+      <Button {...args} leftIcon={true} rightIcon={true}>Large Icon</Button>
     </div>
   ),
 };
@@ -142,14 +139,12 @@ export const Disabled: Story = {
   },
 };
 
-// ...existing code...
-
 export const AllButtons: Story = {
   render: () => {
     const variants = [
-      "primary-filled", "primary-neutral", "primary-transparent", "primary-inversed",
-      "secondary-filled", "secondary-inversed", "secondary-neutral", "secondary-outlined",
-      "secondary-transparent", "secondary-translucent",
+      "primaryFilled", "primaryNeutral", "primaryTransparent", "primaryInversed",
+      "secondaryFilled", "secondaryInversed", "secondaryNeutral", "secondaryOutlined",
+      "secondaryTransparent", "secondaryTranslucent",
     ] as const;
     const sizes = ["sm", "md", "lg"] as const;
     const shapes = ["default", "rounded"] as const;
@@ -159,37 +154,35 @@ export const AllButtons: Story = {
         {/* Variant별 버튼 (아이콘 없음, 기본 size/md, shape/default) */}
         <div>
           <h3 className="mb-2 font-bold">Variants (No Icon, Default Size/Shape)</h3>
-          <div className="grid grid-cols-5 gap-4">
+          <div className="flex flex-wrap gap-4">
             {variants.map(variant => (
               <Button key={variant} variant={variant}>
                 {variant}
               </Button>
             ))}
-            <Button variant="primary-filled" disabled>Disabled</Button>
-            {/* <Button variant="primary-filled" loading>Loading</Button> */}
+            <Button variant="primaryFilled" disabled={true}>Disabled</Button>
           </div>
         </div>
 
         {/* Variant별 버튼 (Left + Right Icon, 기본 size/md, shape/default) */}
         <div>
           <h3 className="mb-2 font-bold">Variants (With Left + Right Icons)</h3>
-          <div className="grid grid-cols-5 gap-4">
+          <div className="flex flex-wrap gap-4">
             {variants.map(variant => (
-          <Button key={variant} variant={variant} leftIcon={true} rightIcon={true}>
+              <Button key={variant} variant={variant} leftIcon={true} rightIcon={true}>
                 {variant}
               </Button>
             ))}
-        <Button variant="primary-filled" disabled leftIcon={true} rightIcon={true}>Disabled Icons</Button>
-            {/* <Button variant="primary-filled" loading leftIcon={true} rightIcon={true} iconSize="20px">Loading Icons</Button> */}
+            <Button variant="primaryFilled" disabled leftIcon={true} rightIcon={true}>Disabled Icons</Button>
           </div>
         </div>
 
         {/* Variant별 버튼 (Left Icon Only) */}
         <div>
           <h3 className="mb-2 font-bold">Variants (Left Icon Only)</h3>
-          <div className="grid grid-cols-5 gap-4">
+          <div className="flex flex-wrap gap-4">
             {variants.map(variant => (
-          <Button key={variant} variant={variant} leftIcon={true}>
+              <Button key={variant} variant={variant} leftIcon={true}>
                 {variant}
               </Button>
             ))}
@@ -199,64 +192,61 @@ export const AllButtons: Story = {
         {/* Variant별 버튼 (Right Icon Only) */}
         <div>
           <h3 className="mb-2 font-bold">Variants (Right Icon Only)</h3>
-          <div className="grid grid-cols-5 gap-4">
+          <div className="flex flex-wrap gap-4">
             {variants.map(variant => (
-          <Button key={variant} variant={variant} rightIcon={true}>
+              <Button key={variant} variant={variant} rightIcon={true}>
                 {variant}
               </Button>
             ))}
           </div>
         </div>
 
-        {/* Size별 버튼 (기본 variant/primary-filled, shape/default, 아이콘 유무 조합) */}
+        {/* Size별 버튼 (기본 variant/primaryFilled, shape/default, 아이콘 유무 조합) */}
         <div>
           <h3 className="mb-2 font-bold">Sizes (With/Without Icons)</h3>
           <div className="flex flex-col gap-4">
             {sizes.map(size => (
-              <div key={size} className="flex gap-4">
+              <div key={size} className="flex flex-wrap gap-4">
                 <Button size={size}>No Icon {size}</Button>
                 <Button size={size} leftIcon={true}>Left Icon {size}</Button>
                 <Button size={size} rightIcon={true}>Right Icon {size}</Button>
                 <Button size={size} leftIcon={true} rightIcon={true}>Both Icons {size}</Button>
                 <Button size={size} disabled>Disabled {size}</Button>
-                {/* <Button size={size} loading>Loading {size}</Button> */}
               </div>
             ))}
           </div>
         </div>
 
-        {/* Shape별 버튼 (기본 variant/primary-filled, size/md, 아이콘 유무 조합) */}
+        {/* Shape별 버튼 (기본 variant/primaryFilled, size/md, 아이콘 유무 조합) */}
         <div>
           <h3 className="mb-2 font-bold">Shapes (With/Without Icons)</h3>
           <div className="flex flex-col gap-4">
             {shapes.map(shape => (
-              <div key={shape} className="flex gap-4">
+              <div key={shape} className="flex flex-wrap gap-4">
                 <Button shape={shape}>No Icon {shape}</Button>
                 <Button shape={shape} leftIcon={true}>Left Icon {shape}</Button>
                 <Button shape={shape} rightIcon={true}>Right Icon {shape}</Button>
                 <Button shape={shape} leftIcon={true} rightIcon={true}>Both Icons {shape}</Button>
                 <Button shape={shape} disabled>Disabled {shape}</Button>
-                {/* <Button shape={shape} loading>Loading {shape}</Button> */}
               </div>
             ))}
           </div>
         </div>
 
-        {/* Mixed 조합 예시 (e.g., different size + shape + variant + icons) */}
+        {/* Mixed 조합 예시 */}
         <div>
           <h3 className="mb-2 font-bold">Mixed Combinations</h3>
           <div className="flex flex-wrap gap-4">
-            <Button variant="secondary-outlined" size="sm" shape="rounded" leftIcon={true}>Small Rounded Outlined Left</Button>
-            <Button variant="primary-transparent" size="lg" shape="default" rightIcon={true}>Large Default Transparent Right</Button>
-            <Button variant="secondary-translucent" size="md" shape="rounded" leftIcon={true} rightIcon={true}>Medium Rounded Translucent Both</Button>
-            <Button variant="primary-inversed" size="sm" shape="default" disabled>Small Default Inversed Disabled</Button>
-            {/* <Button variant="secondary-neutral" size="lg" shape="rounded" loading>Large Rounded Neutral Loading</Button> */}
+            <Button variant="secondaryOutlined" size="sm" shape="rounded" leftIcon={true}>Small Rounded Outlined Left</Button>
+            <Button variant="primaryTransparent" size="lg" shape="default" rightIcon={true}>Large Default Transparent Right</Button>
+            <Button variant="secondaryTranslucent" size="md" shape="rounded" leftIcon={true} rightIcon={true}>Medium Rounded Translucent Both</Button>
+            <Button variant="primaryInversed" size="sm" shape="default" disabled>Small Default Inversed Disabled</Button>
           </div>
         </div>
       </div>
     );
   },
   parameters: {
-    docs: { description: { story: "모든 경우 커버: variant, size, shape, icons (left/right/both/none), disabled/loading. Grid로 시각화 (Storybook 8.5+ 베스트 프랙티스)." } },
+    docs: { description: { story: "모든 경우 커버: variant, size, shape, icons (left/right/both/none), disabled/loading. 카멜케이스 variant 사용." } },
   },
 };

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -24,9 +24,8 @@ const meta: Meta<typeof Button> = {
     shape: { control: "radio", options: ["default", "rounded"], description: "모양" },
     leftIcon: { control: "boolean", description: "왼쪽 아이콘 표시 (StarIcon 사용)" },
     rightIcon: { control: "boolean", description: "오른쪽 아이콘 표시 (StarIcon 사용)" },
-    iconSize: { control: "text", description: "아이콘 크기 (e.g., 20px)" },
     disabled: { control: "boolean", description: "비활성화" },
-    loading: { control: "boolean", description: "로딩 상태 (React 19 useTransition과 결합)" },
+  // ...existing code...
     children: { control: "text", defaultValue: "Button" },
   },
   tags: ["autodocs"], // 자동 문서화 활성화 (Storybook 8+ 베스트 프랙티스)
@@ -113,9 +112,9 @@ export const WithIcons: Story = {
   },
   render: (args) => (
     <div className="flex gap-4">
-      <Button {...args} leftIcon={true} rightIcon={true} iconSize="16px">Small Icon</Button>
-      <Button {...args} leftIcon={true} rightIcon={true} iconSize="20px">Default Icon</Button>
-      <Button {...args} leftIcon={true} rightIcon={true} iconSize="24px">Large Icon</Button>
+  <Button {...args} leftIcon={true} rightIcon={true}>Small Icon</Button>
+  <Button {...args} leftIcon={true} rightIcon={true}>Default Icon</Button>
+  <Button {...args} leftIcon={true} rightIcon={true}>Large Icon</Button>
     </div>
   ),
 };
@@ -143,15 +142,7 @@ export const Disabled: Story = {
   },
 };
 
-export const Loading: Story = {
-  args: {
-    loading: true,
-    children: "Loading",
-  },
-  parameters: {
-    docs: { description: { story: "로딩 상태: aria-busy=true, React 19 useTransition과 결합 추천." } },
-  },
-};
+// ...existing code...
 
 export const AllButtons: Story = {
   render: () => {
@@ -175,7 +166,7 @@ export const AllButtons: Story = {
               </Button>
             ))}
             <Button variant="primary-filled" disabled>Disabled</Button>
-            <Button variant="primary-filled" loading>Loading</Button>
+            {/* <Button variant="primary-filled" loading>Loading</Button> */}
           </div>
         </div>
 
@@ -184,12 +175,12 @@ export const AllButtons: Story = {
           <h3 className="mb-2 font-bold">Variants (With Left + Right Icons)</h3>
           <div className="grid grid-cols-5 gap-4">
             {variants.map(variant => (
-              <Button key={variant} variant={variant} leftIcon={true} rightIcon={true} iconSize="20px">
+          <Button key={variant} variant={variant} leftIcon={true} rightIcon={true}>
                 {variant}
               </Button>
             ))}
-            <Button variant="primary-filled" disabled leftIcon={true} rightIcon={true} iconSize="20px">Disabled Icons</Button>
-            <Button variant="primary-filled" loading leftIcon={true} rightIcon={true} iconSize="20px">Loading Icons</Button>
+        <Button variant="primary-filled" disabled leftIcon={true} rightIcon={true}>Disabled Icons</Button>
+            {/* <Button variant="primary-filled" loading leftIcon={true} rightIcon={true} iconSize="20px">Loading Icons</Button> */}
           </div>
         </div>
 
@@ -198,7 +189,7 @@ export const AllButtons: Story = {
           <h3 className="mb-2 font-bold">Variants (Left Icon Only)</h3>
           <div className="grid grid-cols-5 gap-4">
             {variants.map(variant => (
-              <Button key={variant} variant={variant} leftIcon={true} iconSize="20px">
+          <Button key={variant} variant={variant} leftIcon={true}>
                 {variant}
               </Button>
             ))}
@@ -210,7 +201,7 @@ export const AllButtons: Story = {
           <h3 className="mb-2 font-bold">Variants (Right Icon Only)</h3>
           <div className="grid grid-cols-5 gap-4">
             {variants.map(variant => (
-              <Button key={variant} variant={variant} rightIcon={true} iconSize="20px">
+          <Button key={variant} variant={variant} rightIcon={true}>
                 {variant}
               </Button>
             ))}
@@ -224,11 +215,11 @@ export const AllButtons: Story = {
             {sizes.map(size => (
               <div key={size} className="flex gap-4">
                 <Button size={size}>No Icon {size}</Button>
-                <Button size={size} leftIcon={true} iconSize={size === "sm" ? "16px" : size === "md" ? "20px" : "24px"}>Left Icon {size}</Button>
-                <Button size={size} rightIcon={true} iconSize={size === "sm" ? "16px" : size === "md" ? "20px" : "24px"}>Right Icon {size}</Button>
-                <Button size={size} leftIcon={true} rightIcon={true} iconSize={size === "sm" ? "16px" : size === "md" ? "20px" : "24px"}>Both Icons {size}</Button>
+                <Button size={size} leftIcon={true}>Left Icon {size}</Button>
+                <Button size={size} rightIcon={true}>Right Icon {size}</Button>
+                <Button size={size} leftIcon={true} rightIcon={true}>Both Icons {size}</Button>
                 <Button size={size} disabled>Disabled {size}</Button>
-                <Button size={size} loading>Loading {size}</Button>
+                {/* <Button size={size} loading>Loading {size}</Button> */}
               </div>
             ))}
           </div>
@@ -241,11 +232,11 @@ export const AllButtons: Story = {
             {shapes.map(shape => (
               <div key={shape} className="flex gap-4">
                 <Button shape={shape}>No Icon {shape}</Button>
-                <Button shape={shape} leftIcon={true} iconSize="20px">Left Icon {shape}</Button>
-                <Button shape={shape} rightIcon={true} iconSize="20px">Right Icon {shape}</Button>
-                <Button shape={shape} leftIcon={true} rightIcon={true} iconSize="20px">Both Icons {shape}</Button>
+                <Button shape={shape} leftIcon={true}>Left Icon {shape}</Button>
+                <Button shape={shape} rightIcon={true}>Right Icon {shape}</Button>
+                <Button shape={shape} leftIcon={true} rightIcon={true}>Both Icons {shape}</Button>
                 <Button shape={shape} disabled>Disabled {shape}</Button>
-                <Button shape={shape} loading>Loading {shape}</Button>
+                {/* <Button shape={shape} loading>Loading {shape}</Button> */}
               </div>
             ))}
           </div>
@@ -255,11 +246,11 @@ export const AllButtons: Story = {
         <div>
           <h3 className="mb-2 font-bold">Mixed Combinations</h3>
           <div className="flex flex-wrap gap-4">
-            <Button variant="secondary-outlined" size="sm" shape="rounded" leftIcon={true} iconSize="16px">Small Rounded Outlined Left</Button>
-            <Button variant="primary-transparent" size="lg" shape="default" rightIcon={true} iconSize="24px">Large Default Transparent Right</Button>
-            <Button variant="secondary-translucent" size="md" shape="rounded" leftIcon={true} rightIcon={true} iconSize="20px">Medium Rounded Translucent Both</Button>
+            <Button variant="secondary-outlined" size="sm" shape="rounded" leftIcon={true}>Small Rounded Outlined Left</Button>
+            <Button variant="primary-transparent" size="lg" shape="default" rightIcon={true}>Large Default Transparent Right</Button>
+            <Button variant="secondary-translucent" size="md" shape="rounded" leftIcon={true} rightIcon={true}>Medium Rounded Translucent Both</Button>
             <Button variant="primary-inversed" size="sm" shape="default" disabled>Small Default Inversed Disabled</Button>
-            <Button variant="secondary-neutral" size="lg" shape="rounded" loading>Large Rounded Neutral Loading</Button>
+            {/* <Button variant="secondary-neutral" size="lg" shape="rounded" loading>Large Rounded Neutral Loading</Button> */}
           </div>
         </div>
       </div>

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,271 @@
+import React from "react";
+import { userEvent } from "@storybook/test";
+import { Button } from "../app/components/Button";
+import type { StoryObj, Meta } from "@storybook/nextjs";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+    docs: { description: { component: "버튼 컴포넌트: primary/secondary variants, size, shape, left/right icon, loading 지원. 접근성(ARIA) 강화." } },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [
+        "primary-filled", "primary-neutral", "primary-transparent", "primary-inversed",
+        "secondary-filled", "secondary-inversed", "secondary-neutral", "secondary-outlined",
+        "secondary-transparent", "secondary-translucent", "disabled",
+      ],
+      description: "버튼 테마",
+    },
+    size: { control: "radio", options: ["sm", "md", "lg"], description: "크기" },
+    shape: { control: "radio", options: ["default", "rounded"], description: "모양" },
+    leftIcon: { control: "boolean", description: "왼쪽 아이콘 표시 (StarIcon 사용)" },
+    rightIcon: { control: "boolean", description: "오른쪽 아이콘 표시 (StarIcon 사용)" },
+    iconSize: { control: "text", description: "아이콘 크기 (e.g., 20px)" },
+    disabled: { control: "boolean", description: "비활성화" },
+    loading: { control: "boolean", description: "로딩 상태 (React 19 useTransition과 결합)" },
+    children: { control: "text", defaultValue: "Button" },
+  },
+  tags: ["autodocs"], // 자동 문서화 활성화 (Storybook 8+ 베스트 프랙티스)
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    children: "Default Button",
+  },
+  play: async () => {
+    await userEvent.tab(); // 키보드 포커스 테스트
+    await new Promise(resolve => setTimeout(resolve, 300)); // 지연으로 시각화
+  },
+};
+
+export const Focused: Story = {
+  render: () => (
+    <div className="grid grid-cols-3 gap-4">
+      <Button variant="primary-filled">Primary Filled Focused</Button>
+      <Button variant="secondary-outlined">Secondary Outlined Focused</Button>
+      <Button variant="primary-transparent" disabled>Disabled (No Focus)</Button>
+    </div>
+  ),
+  parameters: {
+    docs: { description: { story: "포커스 상태 테스트: Tab 키로 확인. 접근성 강화 (ARIA 속성)." } },
+  },
+  // play 함수 제거: 사용자가 직접 Tab 키로 포커스 테스트 (Storybook 8.5+ Test runner 추천으로 별도 테스트)
+};
+
+export const PrimaryVariants: Story = {
+  render: () => (
+    <div className="grid grid-cols-4 gap-4">
+      <Button variant="primary-filled">Filled</Button>
+      <Button variant="primary-neutral">Neutral</Button>
+      <Button variant="primary-transparent">Transparent</Button>
+      <Button variant="primary-inversed">Inversed</Button>
+      <Button variant="primary-filled" disabled>Disabled Filled</Button>
+    </div>
+  ),
+};
+
+export const SecondaryVariants: Story = {
+  render: () => (
+    <div className="grid grid-cols-4 gap-4">
+      <Button variant="secondary-filled">Filled</Button>
+      <Button variant="secondary-inversed">Inversed</Button>
+      <Button variant="secondary-neutral">Neutral</Button>
+      <Button variant="secondary-outlined">Outlined</Button>
+      <Button variant="secondary-transparent">Transparent</Button>
+      <Button variant="secondary-translucent">Translucent</Button>
+      <Button variant="secondary-filled" disabled>Disabled Filled</Button>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};
+
+export const Shapes: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button shape="default">Default</Button>
+      <Button shape="rounded">Rounded</Button>
+    </div>
+  ),
+};
+
+// WithIcons, LeftIconOnly, RightIconOnly 등에서 leftIcon/rightIcon이 true면 DefaultSvgIcon을 넘김
+export const WithIcons: Story = {
+  args: {
+    leftIcon: true,
+    rightIcon: true,
+    children: "With Icons",
+  },
+  render: (args) => (
+    <div className="flex gap-4">
+      <Button {...args} leftIcon={true} rightIcon={true} iconSize="16px">Small Icon</Button>
+      <Button {...args} leftIcon={true} rightIcon={true} iconSize="20px">Default Icon</Button>
+      <Button {...args} leftIcon={true} rightIcon={true} iconSize="24px">Large Icon</Button>
+    </div>
+  ),
+};
+
+export const LeftIconOnly: Story = {
+  args: {
+    leftIcon: true,
+    children: "Left Icon Only",
+  },
+  render: (args) => <Button {...args} leftIcon={true}>Left Icon</Button>,
+};
+
+export const RightIconOnly: Story = {
+  args: {
+    rightIcon: true,
+    children: "Right Icon Only",
+  },
+  render: (args) => <Button {...args} rightIcon={true}>Right Icon</Button>,
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: "Disabled",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    children: "Loading",
+  },
+  parameters: {
+    docs: { description: { story: "로딩 상태: aria-busy=true, React 19 useTransition과 결합 추천." } },
+  },
+};
+
+export const AllButtons: Story = {
+  render: () => {
+    const variants = [
+      "primary-filled", "primary-neutral", "primary-transparent", "primary-inversed",
+      "secondary-filled", "secondary-inversed", "secondary-neutral", "secondary-outlined",
+      "secondary-transparent", "secondary-translucent",
+    ] as const;
+    const sizes = ["sm", "md", "lg"] as const;
+    const shapes = ["default", "rounded"] as const;
+
+    return (
+      <div className="flex flex-col gap-8">
+        {/* Variant별 버튼 (아이콘 없음, 기본 size/md, shape/default) */}
+        <div>
+          <h3 className="mb-2 font-bold">Variants (No Icon, Default Size/Shape)</h3>
+          <div className="grid grid-cols-5 gap-4">
+            {variants.map(variant => (
+              <Button key={variant} variant={variant}>
+                {variant}
+              </Button>
+            ))}
+            <Button variant="primary-filled" disabled>Disabled</Button>
+            <Button variant="primary-filled" loading>Loading</Button>
+          </div>
+        </div>
+
+        {/* Variant별 버튼 (Left + Right Icon, 기본 size/md, shape/default) */}
+        <div>
+          <h3 className="mb-2 font-bold">Variants (With Left + Right Icons)</h3>
+          <div className="grid grid-cols-5 gap-4">
+            {variants.map(variant => (
+              <Button key={variant} variant={variant} leftIcon={true} rightIcon={true} iconSize="20px">
+                {variant}
+              </Button>
+            ))}
+            <Button variant="primary-filled" disabled leftIcon={true} rightIcon={true} iconSize="20px">Disabled Icons</Button>
+            <Button variant="primary-filled" loading leftIcon={true} rightIcon={true} iconSize="20px">Loading Icons</Button>
+          </div>
+        </div>
+
+        {/* Variant별 버튼 (Left Icon Only) */}
+        <div>
+          <h3 className="mb-2 font-bold">Variants (Left Icon Only)</h3>
+          <div className="grid grid-cols-5 gap-4">
+            {variants.map(variant => (
+              <Button key={variant} variant={variant} leftIcon={true} iconSize="20px">
+                {variant}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {/* Variant별 버튼 (Right Icon Only) */}
+        <div>
+          <h3 className="mb-2 font-bold">Variants (Right Icon Only)</h3>
+          <div className="grid grid-cols-5 gap-4">
+            {variants.map(variant => (
+              <Button key={variant} variant={variant} rightIcon={true} iconSize="20px">
+                {variant}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {/* Size별 버튼 (기본 variant/primary-filled, shape/default, 아이콘 유무 조합) */}
+        <div>
+          <h3 className="mb-2 font-bold">Sizes (With/Without Icons)</h3>
+          <div className="flex flex-col gap-4">
+            {sizes.map(size => (
+              <div key={size} className="flex gap-4">
+                <Button size={size}>No Icon {size}</Button>
+                <Button size={size} leftIcon={true} iconSize={size === "sm" ? "16px" : size === "md" ? "20px" : "24px"}>Left Icon {size}</Button>
+                <Button size={size} rightIcon={true} iconSize={size === "sm" ? "16px" : size === "md" ? "20px" : "24px"}>Right Icon {size}</Button>
+                <Button size={size} leftIcon={true} rightIcon={true} iconSize={size === "sm" ? "16px" : size === "md" ? "20px" : "24px"}>Both Icons {size}</Button>
+                <Button size={size} disabled>Disabled {size}</Button>
+                <Button size={size} loading>Loading {size}</Button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Shape별 버튼 (기본 variant/primary-filled, size/md, 아이콘 유무 조합) */}
+        <div>
+          <h3 className="mb-2 font-bold">Shapes (With/Without Icons)</h3>
+          <div className="flex flex-col gap-4">
+            {shapes.map(shape => (
+              <div key={shape} className="flex gap-4">
+                <Button shape={shape}>No Icon {shape}</Button>
+                <Button shape={shape} leftIcon={true} iconSize="20px">Left Icon {shape}</Button>
+                <Button shape={shape} rightIcon={true} iconSize="20px">Right Icon {shape}</Button>
+                <Button shape={shape} leftIcon={true} rightIcon={true} iconSize="20px">Both Icons {shape}</Button>
+                <Button shape={shape} disabled>Disabled {shape}</Button>
+                <Button shape={shape} loading>Loading {shape}</Button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Mixed 조합 예시 (e.g., different size + shape + variant + icons) */}
+        <div>
+          <h3 className="mb-2 font-bold">Mixed Combinations</h3>
+          <div className="flex flex-wrap gap-4">
+            <Button variant="secondary-outlined" size="sm" shape="rounded" leftIcon={true} iconSize="16px">Small Rounded Outlined Left</Button>
+            <Button variant="primary-transparent" size="lg" shape="default" rightIcon={true} iconSize="24px">Large Default Transparent Right</Button>
+            <Button variant="secondary-translucent" size="md" shape="rounded" leftIcon={true} rightIcon={true} iconSize="20px">Medium Rounded Translucent Both</Button>
+            <Button variant="primary-inversed" size="sm" shape="default" disabled>Small Default Inversed Disabled</Button>
+            <Button variant="secondary-neutral" size="lg" shape="rounded" loading>Large Rounded Neutral Loading</Button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: { description: { story: "모든 경우 커버: variant, size, shape, icons (left/right/both/none), disabled/loading. Grid로 시각화 (Storybook 8.5+ 베스트 프랙티스)." } },
+  },
+};


### PR DESCRIPTION
## 이슈 넘버
#13 

## 구현 사항
cva를 이용해 Buttom 컴포넌트를 사용할때 variant, size, shape를 받아서 버튼 생성

<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 피그마의 버튼 컴포넌트 cva로 생성
- [ ]
- [ ]
- [ ]

## Need Review
variant로 피그마의 type-style을 Button의 varaint로 받아서 사용한다 기본값은 primary-filled
size는 lg, sm, md 세 종류 존재 기본값은 md
shape는 default와 rounded, default는 8px, rounded는 100px로 설정해두었다.기본값은 8px
leftIcon과 rightIcon을 각각 true로 해서 현재 아이콘을 버튼에 추가할 수 있다. 기본값은 false
true를 주면 기본 아이콘,그 외에 다른 svg 컴포넌트를 전달하면 이미지 변경 가능하다

